### PR TITLE
refactor: split firstboot script per node

### DIFF
--- a/scripts/controlplane-secondary-template.sh
+++ b/scripts/controlplane-secondary-template.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash
+# k8s install script for additional control plane node
+# for some reason i don't understand, both /bin/bash and /usr/bin/bash are bash v5.x
+# but only the later knows about [[ which makes me think dash is used instead which
+# means the shebang has to be as above
+
+# Initial setup
+readonly LOG_FILE="/var/log/k8s-firstboot.log"
+touch $LOG_FILE
+exec &>$LOG_FILE
+
+# Log function
+log() {
+	echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+# Sleep to ensure everything is set up
+log "Sleep 5s just to be sure everything else is set up"
+sleep 5
+
+# Get configuration values
+log "Retrieving configuration values"
+TOKEN="$(cat /root/kubeadm-init-token)"
+CERT_KEY="$(cat /root/kubeadm-cert-key)"
+CP_IP=$(resolvectl query -4 controlplane | grep controlplane | cut -f2 -d' ')
+
+# Join as an additional control plane
+log "This is an additional control plane node"
+kubeadm join ${CP_IP}:6443 --token=$TOKEN --control-plane --certificate-key=$CERT_KEY --discovery-token-unsafe-skip-ca-verification
+
+# Cleanup
+log "Disable service to avoid issue in case of reboot"
+systemctl disable k8s-firstboot.service
+log "Remove install files from /root/"
+rm -f /root/*

--- a/scripts/controlplane-template.sh
+++ b/scripts/controlplane-template.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/bash
+# k8s install script for first control plane node
+# for some reason i don't understand, both /bin/bash and /usr/bin/bash are bash v5.x
+# but only the later knows about [[ which makes me think dash is used instead which
+# means the shebang has to be as above
+
+# Initial setup
+readonly LOG_FILE="/var/log/k8s-firstboot.log"
+touch $LOG_FILE
+exec &>$LOG_FILE
+
+# Log function
+log() {
+	echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+# Sleep to ensure everything is set up
+log "Sleep 5s just to be sure everything else is set up"
+sleep 5
+
+# Get configuration values
+log "Retrieving configuration values"
+TOKEN="$(cat /root/kubeadm-init-token)"
+CERT_KEY="$(cat /root/kubeadm-cert-key)"
+HOST_IP="$(ip -4 -o addr show end0 | tr -s ' ' | cut -f4 -d' ' | cut -f1 -d/)"
+
+# Initialize the first control plane
+log "This is the first control plane"
+kubeadm init --skip-phases=addon/kube-proxy --service-cidr 10.244.0.0/20 --pod-network-cidr=10.244.64.0/18 --token=$TOKEN --control-plane-endpoint=$HOST_IP --upload-certs --certificate-key=$CERT_KEY
+
+# Install required components
+log "Installing cilium"
+sleep 5 && helm install cilium cilium/cilium --version 1.17.1 --repo https://helm.cilium.io/ --namespace kube-system --set kubeProxyReplacement=true --set k8sServiceHost=$HOST_IP --set k8sServicePort=6443 --set hubble.relay.enabled=true --set hubble.ui.enabled=true
+
+log "Setting up flux"
+sleep 5 && kubectl create secret generic flux-sops --namespace=flux-system --from-file=age.agekey=/root/keys.txt
+sleep 5 && kubectl apply -f https://github.com/controlplaneio-fluxcd/flux-operator/releases/latest/download/install.yaml
+sleep 5 && kubectl apply -f /root/flux-instance.yaml
+
+# Setup kubeconfig for the pi user
+log "Copy config files to pi user home dir"
+cp /etc/kubernetes/admin.conf /home/pi/.kube/config
+chown $(id -u pi):$(id -g pi) /home/pi/.kube/config
+
+# Cleanup
+log "Disable service to avoid issue in case of reboot"
+systemctl disable k8s-firstboot.service
+log "Remove install files from /root/"
+rm -f /root/*

--- a/scripts/worker-template.sh
+++ b/scripts/worker-template.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/bash
+# k8s install script for worker node
+# for some reason i don't understand, both /bin/bash and /usr/bin/bash are bash v5.x
+# but only the later knows about [[ which makes me think dash is used instead which
+# means the shebang has to be as above
+
+# Initial setup
+readonly LOG_FILE="/var/log/k8s-firstboot.log"
+touch $LOG_FILE
+exec &>$LOG_FILE
+
+# Log function
+log() {
+	echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+# Sleep to ensure everything is set up
+log "Sleep 5s just to be sure everything else is set up"
+sleep 5
+
+# Get configuration values
+log "Retrieving configuration values"
+TOKEN="$(cat /root/kubeadm-init-token)"
+CP_IP=$(resolvectl query -4 controlplane | grep controlplane | cut -f2 -d' ')
+
+# Join as a worker node
+log "This is a worker node"
+kubeadm join ${CP_IP}:6443 --token=$TOKEN --discovery-token-unsafe-skip-ca-verification
+
+# Cleanup
+log "Disable service to avoid issue in case of reboot"
+systemctl disable k8s-firstboot.service
+log "Remove install files from /root/"
+rm -f /root/*


### PR DESCRIPTION
1. Created three template files in the scripts directory:
  - controlplane-template.sh - For the first control plane node
  - controlplane-secondary-template.sh - For additional control plane nodes
  - worker-template.sh - For worker nodes
2. Modified the configure-image.sh script to:
  - Determine which template to use based on the hostname
  - Copy the appropriate template to the image
  - Set the correct permissions

This approach has several advantages:
- More modular and maintainable code
- Each machine type's script is in a separate file
- Easier to read and update specific configurations
- Templates can be maintained independently

closes #2